### PR TITLE
Update of the folder's structure and name

### DIFF
--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -21,7 +21,6 @@ export default  function App()
          await checkForLomap(session);
          //Todo if no folder, give the option to create it or to logout
         setIsLoggedIn(true);
-        await placeImageInContainer(session, "C:\\Users\\X421FA\\Documents\\tercero\\lomapen3b\\test.jpg", true);
     });
 //We have logged out
     session.onLogout(() => {

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -5,6 +5,7 @@ import LoginForm from "./views/loginView"
 import { useSession } from "@inrupt/solid-ui-react/dist";
 import { checkForLomap } from './handlers/podHandler';
 import MapView from "./views/mapView";
+import {placeImageInContainer} from "./handlers/podAccess";
 
 export default  function App()
 {
@@ -20,7 +21,7 @@ export default  function App()
          await checkForLomap(session);
          //Todo if no folder, give the option to create it or to logout
         setIsLoggedIn(true);
-
+        await placeImageInContainer(session, "C:\\Users\\X421FA\\Documents\\tercero\\lomapen3b\\test.jpg", true);
     });
 //We have logged out
     session.onLogout(() => {

--- a/webapp/src/components/Map.js
+++ b/webapp/src/components/Map.js
@@ -93,16 +93,16 @@ function Map({ changesInFilters,selectedFilters,isInteractive,session, onMarkerA
       // Function to get and set the locations on the map
     const retrieveLocations=async () => {
         let friends = await getFriendsWebIds(session.info.webId);
-        let resource = session.info.webId.replace("/profile/card#me", "/private/lomap/locations.ttl");
+        let resource = session.info.webId.replace("/profile/card#me", "/private/lomapen3b/locations.ttl");
         // Code to get the friends locations
         let locations = await readLocations(resource, session);
-        resource = session.info.webId.replace("/profile/card#me", "/public/lomap/locations.ttl");
+        resource = session.info.webId.replace("/profile/card#me", "/public/lomapen3b/locations.ttl");
         locations = locations.concat(await readLocations(resource, session));
         let friendsLocations = [];
         for (let i = 0; i < friends.length; i++) {
             try {
                 //concat it with the previous locations (concat returns a new array instead of modifying any of the existing ones)
-                friendsLocations = friendsLocations.concat(await readLocations(friends[i].replace("/profile/card", "/") + "public/lomap/locations.ttl",session));
+                friendsLocations = friendsLocations.concat(await readLocations(friends[i].replace("/profile/card", "/") + "public/lomapen3b/locations.ttl",session));
             } catch (err) {
                 //Friend does not have LoMap??
                 console.log(err);

--- a/webapp/src/handlers/podAccess.js
+++ b/webapp/src/handlers/podAccess.js
@@ -15,7 +15,7 @@ import {
     getThingAll,
     getSolidDataset,
     removeThing,
-    getStringNoLocale, getThing, addUrl, addStringNoLocale
+    getStringNoLocale, getThing, addUrl, addStringNoLocale, saveFileInContainer
 } from "@inrupt/solid-client";
 import { SCHEMA_INRUPT, RDF} from "@inrupt/vocab-common-rdf";
 import {getDefaultSession} from "@inrupt/solid-client-authn-browser";
@@ -302,6 +302,25 @@ async function readReviews(resourceURL,session) {
     return reviewsRetrieved;
 
 }
+
+export async function placeImageInContainer(session, image, isPrivate) {
+    let containerURL = session.info.webId.replace("/profile/card#me", "/");
+    if (isPrivate)
+        containerURL += "private/lomapen3b/images"
+    else
+        containerURL += "public/lomapen3b/images"
+
+    try {
+        const savedImage = await saveFileInContainer(containerURL, image, {
+            slug: image.toString(),
+            contentType: "jpg",
+            fetch: session.fetch
+        })
+    } catch (e) {
+        console.log(e);
+    }
+}
+
 export {
     writeLocations,
     readLocations

--- a/webapp/src/handlers/podAccess.js
+++ b/webapp/src/handlers/podAccess.js
@@ -303,24 +303,6 @@ async function readReviews(resourceURL,session) {
 
 }
 
-export async function placeImageInContainer(session, image, isPrivate) {
-    let containerURL = session.info.webId.replace("/profile/card#me", "/");
-    if (isPrivate)
-        containerURL += "private/lomapen3b/images"
-    else
-        containerURL += "public/lomapen3b/images"
-
-    try {
-        const savedImage = await saveFileInContainer(containerURL, image, {
-            slug: image.toString(),
-            contentType: "jpg",
-            fetch: session.fetch
-        })
-    } catch (e) {
-        console.log(e);
-    }
-}
-
 export {
     writeLocations,
     readLocations

--- a/webapp/src/handlers/podAccess.js
+++ b/webapp/src/handlers/podAccess.js
@@ -15,7 +15,7 @@ import {
     getThingAll,
     getSolidDataset,
     removeThing,
-    getStringNoLocale, getThing, addUrl, addStringNoLocale, saveFileInContainer
+    getStringNoLocale, getThing, addUrl, addStringNoLocale
 } from "@inrupt/solid-client";
 import { SCHEMA_INRUPT, RDF} from "@inrupt/vocab-common-rdf";
 import {getDefaultSession} from "@inrupt/solid-client-authn-browser";

--- a/webapp/src/handlers/podHandler.js
+++ b/webapp/src/handlers/podHandler.js
@@ -59,8 +59,8 @@ export async function checkForLomap(session) {
 export async function checkForLomapInPod(pod,session) {
     try {
 
-     let aux= await getSolidDataset(pod+"public/lomap",{fetch : session.fetch});
-     let aux2= await getSolidDataset(pod+"private/lomap",{fetch : session.fetch});
+     let aux= await getSolidDataset(pod+"public/lomapen3b",{fetch : session.fetch});
+     let aux2= await getSolidDataset(pod+"private/lomapen3b",{fetch : session.fetch});
 
     } catch (error) {
         console.log("Not found lomap folder in pod, we'll try creating one...")
@@ -123,19 +123,18 @@ async function mockFiles(session, resource) {
     }
 }
 
-
 export async function createLomapContainer(pod,session) {
     // create the lomap containers
-    await createContainerAt(pod + "public/lomap/",{fetch : session.fetch});
-    await createContainerAt(pod + "private/lomap/",{fetch : session.fetch});
+    await createContainerAt(pod + "public/lomapen3b/",{fetch : session.fetch});
+    await createContainerAt(pod + "private/lomapen3b/",{fetch : session.fetch});
     // create all the tl files used to store locations and reviews (all empty)
-    await mockFiles(session, session.info.webId.replace("/profile/card#me", "/private/lomap/locations.ttl"));
-    await mockFiles(session, session.info.webId.replace("/profile/card#me", "/public/lomap/locations.ttl"));
-    await mockFiles(session, session.info.webId.replace("/profile/card#me", "/private/lomap/reviews.ttl"));
-    await mockFiles(session, session.info.webId.replace("/profile/card#me", "/public/lomap/reviews.ttl"));
+    await mockFiles(session, session.info.webId.replace("/profile/card#me", "/private/lomapen3b/locations.ttl"));
+    await mockFiles(session, session.info.webId.replace("/profile/card#me", "/public/lomapen3b/locations.ttl"));
+    await mockFiles(session, session.info.webId.replace("/profile/card#me", "/private/lomapen3b/reviews.ttl"));
+    await mockFiles(session, session.info.webId.replace("/profile/card#me", "/public/lomapen3b/reviews.ttl"));
     // create the containers that are going to store the images
-    await createContainerAt(session.info.webId.replace("/profile/card#me", "/public/lomap/images/"), {fetch: session.fetch});
-    await createContainerAt(session.info.webId.replace("/profile/card#me", "/private/lomap/images/"), {fetch: session.fetch});
+    await createContainerAt(session.info.webId.replace("/profile/card#me", "/public/lomapen3b/images/"), {fetch: session.fetch});
+    await createContainerAt(session.info.webId.replace("/profile/card#me", "/private/lomapen3b/images/"), {fetch: session.fetch});
     await giveFriendsAccess(session, true);
 }
 
@@ -162,7 +161,7 @@ export async function getFriendsWebIds(webId) {
 async function giveFriendsAccess(session, access) {
     let currentUser = session.info.webId
     let friends = await getFriendsWebIds(currentUser);
-    let resourceURL = currentUser.replace("/profile/card#me", "/") + "public/lomap/";
+    let resourceURL = currentUser.replace("/profile/card#me", "/") + "public/lomapen3b/";
 
     for (let i = 0; i < friends.length; i++) { //Set access to  public (friends only) locations
         await setAccessToFriend(friends[i].replace("/profile/card","/")+"profile/card#me", resourceURL, access, session);


### PR DESCRIPTION
### **Change in the structure of the project's folder in the pod**
We made the definition of such structure in one of the latest meetings we had. See [here](https://github.com/Arquisoft/lomap_en3b/wiki/Meeting-20-04-2023).

The structure is as follows:
- private (automatically generated by inrupt)
  * lomapen3b (container/folder) 
      * locations.ttl  
      * reviews.ttl 
      * images (container/folder) 
- public (automatically generated by inrupt)
  * lomapen3b (container/folder) 
      * locations.ttl  
      * reviews.ttl 
      * images (container/folder)

### Change in the name of the lomap folder
- This folder was previously called lomap, but in order to avoid conflicts with other applications and pods we have decided to add "en3b" to the end of the name.