### PR TITLE
solved bug having to click twice to login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ yarn-error.log*
 
 #documentation build does not go into master
 docs/build
+/*/keys
 
 /*/.env

--- a/webapp/.idea/.gitignore
+++ b/webapp/.idea/.gitignore
@@ -1,3 +1,4 @@
 # Default ignored files
 /shelf/
 /workspace.xml
+.env

--- a/webapp/.idea/.gitignore
+++ b/webapp/.idea/.gitignore
@@ -2,3 +2,4 @@
 /shelf/
 /workspace.xml
 .env
+.env

--- a/webapp/src/views/loginView.js
+++ b/webapp/src/views/loginView.js
@@ -9,7 +9,7 @@ import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 
 const Login = () => {
-    const [redirectUrl, setRedirectUrl] = useState("");
+    const [redirectUrl, setRedirectUrl] = useState(window.location.href);
     const [provider,setProvider]= useState("https://inrupt.net");
     const authOptions={
         clientName:"LoMap",
@@ -22,6 +22,7 @@ const Login = () => {
 
     }
     const handleLogin = () => {
+
         setRedirectUrl(window.location.href);
     };
 
@@ -57,9 +58,10 @@ const Login = () => {
                         </Select>
                         <InputLabel>(Inrupt By default)</InputLabel>
                     </FormControl>
-                    <LoginButton oidcIssuer={provider} redirectUrl={redirectUrl} authOptions={authOptions}>
+                    <LoginButton oidcIssuer={provider} redirectUrl={redirectUrl} authOptions={authOptions} startIcon={<AccountCircleIcon />}>
                         <Button name="lomapLoginButton" variant="contained" color="inherit" startIcon={<AccountCircleIcon />} onClick={handleLogin}>Login</Button>
                     </LoginButton>
+
                 </Box>
             </Grid>
         </Grid>


### PR DESCRIPTION
The problem was the default value for redirect login state being empty. 

Now, it's solved, and we dont launch two superposed instances of lomap  ( and so , all petitions wont be duplicated)

It's a really small change.

I also changed the git ignore, so the webapp one also excludes changes in .env.